### PR TITLE
chore: add .env support for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "rubocop", "~> 1.21"
+
+group :development do
+  gem "dotenv"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -47,6 +48,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  dotenv
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/bin/setup
+++ b/bin/setup
@@ -6,3 +6,4 @@ set -vx
 bundle install
 
 # Do any other automated setup that you need to do here
+touch .env


### PR DESCRIPTION
# Issue
We'll want developers to have a file for settings env vars/secrets during development, but we never want this to be checked into source. By creating this file by default during setup, we can filter it out from Git and have a standard place to set these values.

# Changes
* Added .env creation to setup script
* Added .env to .gitignore