### PR TITLE
test: add code coverage to testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,18 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rubyoctopus.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
-gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.21"
+# rubocop:disable Style/HashSyntax
+gem "rubocop", "~> 1.21", :group => %i[development test]
+# rubocop:enable Style/HashSyntax
 
 group :development do
   gem "dotenv"
+end
+
+group :test do
+  gem "simplecov", require: false
+
+  gem "rake", "~> 13.0"
+
+  gem "rspec", "~> 3.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dotenv (2.7.6)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -41,9 +42,16 @@ GEM
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     unicode-display_width (2.1.0)
 
 PLATFORMS
+  aarch64-linux
   universal-darwin-20
   x86_64-linux
 
@@ -53,6 +61,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.21)
   rubyoctopus!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+require "simplecov"
+
+SimpleCov.start do
+  enable_coverage :branch
+
+  # Can configure various reporting groups based on code area
+  add_group "Models", "lib/rubyoctopus/model"
+
+  # Filter out folders
+  add_filter "/spec/"
+end
+
+# Set coverage configuration; will fail spec if missed
+SimpleCov.minimum_coverage line: 90, branch: 80
+SimpleCov.minimum_coverage_by_file 70
+
 require "rubyoctopus"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Closes #9.

Confirmed that adding new files without unit tests would cause the coverage to drop and report failure.

This also includes some slight reorganizing of the Gemfile. You'll see that I had trouble with rubocop complaining about using an old syntax. Using the new syntax caused a failure with the `bundle install`, so I just disabled the warning for that line.