### PR TITLE
chore: add pre-commit Rake run

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TODO: Add more examples, as the class gets built out more.
 
 (OPTIONAL) Can use Visual Studio Code to Open Folder in Container via their Remote - Containers extension.
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies and git hooks. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+# Run Rake rubocop task
+rake rubocop

--- a/bin/setup
+++ b/bin/setup
@@ -7,3 +7,6 @@ bundle install
 
 # Do any other automated setup that you need to do here
 touch .env
+
+cp bin/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
This PR adds a pre-commit hook file to the `bin/hooks`. This files gets copied to `.git/hooks` and set to be executable (a requirement for hooks).

The hook itself simply runs the Rake rubocop task, which matches the GitHub workflow that runs for PRs. This should help prevent any accidental pushes that need to be amended for linting issues.

Closes #17.

## Testing
To test this, pull down this branch and either run `bin/setup` or rebuild your dev container. Then, make an obvious formatting issue in a Ruby file and attempt to commit it to whatever local branch you choose. You should see an error pop up saying that running the Rake task failed.