### PR TITLE
Pass query params through for GET

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ruby-octopus/admins

--- a/lib/rubyoctopus/octopusconnection.rb
+++ b/lib/rubyoctopus/octopusconnection.rb
@@ -20,8 +20,15 @@ module RubyOctopus
       end
     end
 
-    def get(resource_type)
-      @conn.get(resource_type)
+    # Makes a GET request to the given URL with the given query parameters.
+    # @param url [String] The URL to be appended on the base URL for the GET request.
+    # @param query_parameters [Hash<String, String>] A hash of query parameters for the request.
+    def get(url, query_parameters = nil)
+      if query_parameters.nil?
+        @conn.get(url)
+      else
+        @conn.get(url, query_parameters)
+      end
     end
   end
 end

--- a/spec/rubyoctopus/octopusconnection_spec.rb
+++ b/spec/rubyoctopus/octopusconnection_spec.rb
@@ -3,6 +3,8 @@
 TEST_URL = "http://www.example.com"
 TEST_API_KEY = "API-FAKEAPIKEY"
 TEST_PATH = "Environments"
+TEST_PARAM = "partialName"
+TEST_PARAM_VALUE = "testing"
 
 RSpec.describe RubyOctopus::OctopusConnection do
   before(:each) do
@@ -28,6 +30,17 @@ RSpec.describe RubyOctopus::OctopusConnection do
     response = @conn.get(TEST_PATH)
 
     # Assert response matches mock
+    expect(response).to be test_response
+  end
+
+  it "sends the correct query parameter" do
+    # Set up response mock
+    test_response = double("Response")
+    test_params = { TEST_PARAM => TEST_PARAM_VALUE }
+    allow(@faraday).to receive(:get).with(TEST_PATH, test_params).and_return(test_response)
+
+    response = @conn.get(TEST_PATH, test_params)
+
     expect(response).to be test_response
   end
 end


### PR DESCRIPTION
Our `get` method on our `OctopusConnection` class wasn't accepting any query parameters. Added passing those through.

I put a type of `Hash<String, String>` in the comment for the query parameters, but personally I use `Hash<Symbol, String>` and Faraday accepts the more raw `String` approach too (e.g. `partialName=test`). I know we shouldn't bank on what the underlying library allows though, as if we ever swap it out the next one might be more stringent.

Also, added a CODEOWNERS file so I don't have to manually select you as a reviewer in the future.