### PR TITLE
feat: add ResourceCollection and resource paging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ Style/StringLiteralsInInterpolation:
 
 Layout/LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  IgnoredMethods: ['describe', 'context']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+- Add ResourceCollection model for paging
+- Add OctopusClient list and paginate methods
 
 ## [0.1.0] - 2022-01-26
 

--- a/lib/rubyoctopus.rb
+++ b/lib/rubyoctopus.rb
@@ -4,6 +4,7 @@ require_relative "rubyoctopus/version"
 require_relative "rubyoctopus/octopusclient"
 require_relative "rubyoctopus/model/environmentresource"
 require_relative "rubyoctopus/model/resource"
+require_relative "rubyoctopus/model/resourcecollection"
 
 module RubyOctopus
   class Error < StandardError; end

--- a/lib/rubyoctopus/model/resourcecollection.rb
+++ b/lib/rubyoctopus/model/resourcecollection.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "resource"
+
+module RubyOctopus
+  module Model
+    # Paging object model containing a list of Resource items.
+    class ResourceCollection < Resource
+      attr_reader :item_type, :total_results, :items_per_page, :number_of_pages, :last_page_number, :items
+
+      def initialize(attribute_values, item_class)
+        raise ArgumentError, "Items cannot be nil." if attribute_values["Items"].nil?
+        raise ArgumentError, "Links cannot be nil." if attribute_values["Links"].nil?
+
+        super(attribute_values)
+        @item_type = attribute_values["ItemType"]
+        @total_results = attribute_values["TotalResults"]
+        @items_per_page = attribute_values["ItemsPerPage"]
+        @number_of_pages = attribute_values["NumberOfPages"]
+        @last_page_number = attribute_values["LastPageNumber"]
+        @items = attribute_values["Items"].map { |item| item_class.new(item) }
+      end
+    end
+  end
+end

--- a/lib/rubyoctopus/octopusclient.rb
+++ b/lib/rubyoctopus/octopusclient.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "octopusconnection"
+require_relative "model/resourcecollection"
 
 module RubyOctopus
   # Base class to use to perform actions against an Octopus instance.
@@ -9,6 +10,34 @@ module RubyOctopus
 
     def initialize(url, api_key)
       @connection = OctopusConnection.new(url, api_key)
+    end
+
+    def collect_params(path, params)
+      return params unless path.include?("?")
+
+      query_string = path.split("?")[1]
+
+      return params if query_string.nil?
+
+      query_string.split("&").each do |param_pair|
+        split_pair = param_pair.split("=")
+        params[split_pair[0]] = split_pair[1]
+      end
+      params
+    end
+
+    def list(path, item_class, params = {})
+      params = collect_params(path, params)
+      resp = @connection.get(path.delete_prefix("/api/"), params)
+      RubyOctopus::Model::ResourceCollection.new(resp.body, item_class)
+    end
+
+    def paginate(path, params, item_class, page_func)
+      page = list(path, item_class, params)
+
+      while page_func.call(page) && page.items.length.positive? && page.link?("Page.Next")
+        page = list(page.link("Page.Next"), item_class)
+      end
     end
   end
 end

--- a/lib/rubyoctopus/octopusconnection.rb
+++ b/lib/rubyoctopus/octopusconnection.rb
@@ -20,8 +20,10 @@ module RubyOctopus
       end
     end
 
-    def get(resource_type)
-      @conn.get(resource_type)
+    def get(path, params = {})
+      @conn.get(path) do |req|
+        req.params = params
+      end
     end
   end
 end

--- a/samples/get_environments.rb
+++ b/samples/get_environments.rb
@@ -12,7 +12,8 @@ response = client.connection.get("Environments")
 puts "Received a #{response.status} response from server"
 
 environments = if response.status == 200
-                 response.body["Items"].map { |item| RubyOctopus::Model::EnvironmentResource.new(item) }
+                 RubyOctopus::Model::ResourceCollection.new(response.body,
+                                                            RubyOctopus::Model::EnvironmentResource).items
                end
 
 environments.each { |environment| puts "#{environment.id}: #{environment.name}" }

--- a/samples/get_environments_one_per_page.rb
+++ b/samples/get_environments_one_per_page.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "dotenv/load"
+
+require_relative "../lib/rubyoctopus"
+
+# Set these values in your .env
+client = RubyOctopus::OctopusClient.new(ENV["OCTOPUS_URL"], ENV["OCTOPUS_API_KEY"])
+
+environments = []
+
+client.paginate("Environments", { "take" => 1 }, RubyOctopus::Model::EnvironmentResource, lambda do |page|
+  environments.concat(page.items)
+  true
+end)
+
+environments.each { |environment| puts "#{environment.id}: #{environment.name}" }

--- a/spec/rubyoctopus/model/resourcecollection_spec.rb
+++ b/spec/rubyoctopus/model/resourcecollection_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe RubyOctopus::Model::ResourceCollection do
+  it "raises error when Items is nil" do
+    attribute_values = { "Links" => {} }
+    expect { RubyOctopus::Model::ResourceCollection.new(attribute_values, double) }.to raise_error(ArgumentError)
+  end
+
+  it "raises error when Links is nil" do
+    attribute_values = { "Items" => {} }
+    expect { RubyOctopus::Model::ResourceCollection.new(attribute_values, double) }.to raise_error(ArgumentError)
+  end
+
+  it "initializes when arguments are correct" do
+    attribute_values = { "Items" => {}, "Links" => {} }
+    RubyOctopus::Model::ResourceCollection.new(attribute_values, double)
+  end
+end

--- a/spec/rubyoctopus/octopusclient_spec.rb
+++ b/spec/rubyoctopus/octopusclient_spec.rb
@@ -2,18 +2,81 @@
 
 TEST_URL = "http://www.example.com"
 TEST_API_KEY = "API-FAKEAPIKEY"
+TEST_PATH = "Environments"
+TEST_PARAMS = { "key1" => "value1" }.freeze
 
 RSpec.describe RubyOctopus::OctopusClient do
-  it "has a connection after initialization" do
+  before(:each) do
     # Set up connection mock
-    connection = double("Connection")
-    allow(RubyOctopus::OctopusConnection).to receive(:new).with(TEST_URL, TEST_API_KEY).and_return(connection)
+    @connection = double("Connection")
+    allow(RubyOctopus::OctopusConnection).to receive(:new).with(TEST_URL, TEST_API_KEY).and_return(@connection)
 
     # Call constructor
-    client = RubyOctopus::OctopusClient.new(TEST_URL, TEST_API_KEY)
+    @client = RubyOctopus::OctopusClient.new(TEST_URL, TEST_API_KEY)
+  end
 
-    # Assertions
-    expect(client.connection).not_to be nil
-    expect(client.connection).to be connection
+  it "has a connection after initialization" do
+    expect(@client.connection).not_to be nil
+    expect(@client.connection).to be @connection
+  end
+
+  it "returns params when path doesn't have any" do
+    params = @client.collect_params("/", { "key1" => "value1" })
+    expect(params["key1"]).to be "value1"
+
+    params = @client.collect_params("/?", { "key2" => "value2" })
+    expect(params["key2"]).to be "value2"
+  end
+
+  it "collects params from both sources" do
+    params = @client.collect_params("/?query_key=query_value", { "key3" => "value3" })
+    expect(params["query_key"]).to eq("query_value")
+    expect(params["key3"]).to be "value3"
+  end
+
+  it "returns a ResourceCollection for the right path" do
+    clazz = double("Class")
+    response = double("Response")
+    resource_collection = double("ResourceCollection")
+    allow(resource_collection).to receive(:items).and_return(["items"])
+    allow(@client).to receive(:collect_params).with(TEST_PATH, TEST_PARAMS).and_return(TEST_PARAMS)
+    allow(@connection).to receive(:get).with(TEST_PATH, TEST_PARAMS).and_return(response)
+    allow(response).to receive(:body).and_return("body")
+    allow(RubyOctopus::Model::ResourceCollection).to receive(:new).with("body", clazz).and_return(resource_collection)
+
+    resources = @client.list(TEST_PATH, clazz, TEST_PARAMS)
+
+    expect(resources.items).to eq(["items"])
+  end
+
+  it "paginates" do
+    accumulator = []
+
+    clazz = double("Class")
+    page_func = lambda do |page|
+      accumulator.concat(page.items)
+      true
+    end
+    resource_collection1 = double("ResourceCollection1")
+    resource_collection2 = double("ResourceCollection2")
+    resource_collection3 = double("ResourceCollection3")
+    allow(resource_collection1).to receive(:items).and_return([1])
+    allow(resource_collection1).to receive(:link?).with("Page.Next").and_return(true)
+    allow(resource_collection1).to receive(:link).with("Page.Next").and_return("next1")
+    allow(resource_collection2).to receive(:items).and_return([2])
+    allow(resource_collection2).to receive(:link?).with("Page.Next").and_return(true)
+    allow(resource_collection2).to receive(:link).with("Page.Next").and_return("next2")
+    allow(resource_collection3).to receive(:items).and_return([3])
+    allow(resource_collection3).to receive(:link?).with("Page.Next").and_return(false)
+    allow(@client).to receive(:list).with(TEST_PATH, clazz, TEST_PARAMS).and_return(resource_collection1)
+    allow(@client).to receive(:list).with("next1", clazz).and_return(resource_collection2)
+    allow(@client).to receive(:list).with("next2", clazz).and_return(resource_collection3)
+
+    @client.paginate(TEST_PATH, TEST_PARAMS, clazz, page_func)
+
+    expect(accumulator.length).to be 3
+    expect(accumulator[0]).to be 1
+    expect(accumulator[1]).to be 2
+    expect(accumulator[2]).to be 3
   end
 end

--- a/spec/rubyoctopus/octopusconnection_spec.rb
+++ b/spec/rubyoctopus/octopusconnection_spec.rb
@@ -3,11 +3,30 @@
 TEST_URL = "http://www.example.com"
 TEST_API_KEY = "API-FAKEAPIKEY"
 TEST_PATH = "Environments"
+PARAM_TEST_PATH = "param-test"
 
 RSpec.describe RubyOctopus::OctopusConnection do
   before(:each) do
     # Set up Faraday mock
-    @faraday = double("Faraday")
+    @faraday = Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.get("/Environments") do |_env|
+          [
+            200,
+            { "Content-Type": "text/plain" },
+            "shrimp"
+          ]
+        end
+
+        stub.get("/param-test?key=value") do |_env|
+          [
+            200,
+            {},
+            "Param test response body"
+          ]
+        end
+      end
+    end
     allow(@faraday).to receive(:adapter).with(Faraday.default_adapter)
     allow(@faraday).to receive(:response).with(:json)
     allow(Faraday).to receive(:new).and_yield(@faraday).and_return(@faraday)
@@ -17,17 +36,18 @@ RSpec.describe RubyOctopus::OctopusConnection do
   end
 
   it "has the correct URL" do
-    expect(@conn.url).to be TEST_URL
+    expect(@conn.url).to eq(TEST_URL)
   end
 
   it "gets the correct path" do
-    # Set up response mock
-    test_response = double("Response")
-    allow(@faraday).to receive(:get).with(TEST_PATH).and_return(test_response)
-
     response = @conn.get(TEST_PATH)
 
     # Assert response matches mock
-    expect(response).to be test_response
+    expect(response.status).to be 200
+  end
+
+  it "gets the correct params" do
+    response = @conn.get(PARAM_TEST_PATH, { "key" => "value" })
+    expect(response.body).to be "Param test response body"
   end
 end


### PR DESCRIPTION
# Changes
This PR adds the `ResourceCollection` class for holding responses from paging endpoints. It also adds the `list` and `paginate` methods to the client class, which allow for getting a `ResourceCollection` response from an endpoint as well as using it to page through a resource.

# Testing
I included a new sample script that will page through environments one at a time and add them to an array. I also added a Faraday stub server in the connection class to make future testing easier.

# TODO
- [ ] The code in this PR needs comments