### PR TITLE
Pre-commit fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ RSpec::Core::RakeTask.new(:spec)
 
 require "rubocop/rake_task"
 
-RuboCop::RakeTask.new
+RuboCop::RakeTask.new do |t|
+  t.options = ["--auto-correct-all"]
+end
 
 task default: %i[spec rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,9 @@ RuboCop::RakeTask.new do |t|
   t.options = ["--auto-correct-all"]
 end
 
+RuboCop::RakeTask.new("rubocop:staged") do |t|
+  staged_ruby_files = `git diff --cached --name-only | grep -E '\.rb$'`
+  t.patterns = staged_ruby_files.split()
+end
+
 task default: %i[spec rubocop]

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -3,5 +3,10 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-# Run Rake rubocop task
-rake rubocop
+# Run Rake rubocop task if Ruby files are staged
+if [[ $(git diff --cached --name-only | grep -E '\.rb$') ]]; then
+    echo "Linting staged Ruby files"
+    rake rubocop:staged
+else
+    echo "No Ruby files staged; skipping lint"
+fi


### PR DESCRIPTION
Closes #22. The only part I'm not sure of is the mid-rebase Rake calls that seem to fail on a require. I'm less worried about that portion of it, though, and much more worried about the pre-commit hook preventing good commits due to a dirty workspace.

## Testing
To test this out, re-run `bin/setup` to get the updated hook and then stage a **good** change to a Ruby file. Meanwhile, make another change to an indexed Ruby file that would get flagged by rubocop and _do not_ stage it. You should be able to commit the first file regardless.

Additionally, stage a change to a non-Ruby file. You should be able to commit this no matter what. You should see in the Git log that there were no Ruby files detected.